### PR TITLE
Tweaked the makefile with current hdf5 installation dir and libnames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 OS_NAME=$(shell uname -s)
-H5DIR=/usr/local/Cellar/hdf5/1.10.1_2/lib/
+H5DIR=/usr/include/hdf5/serial/
 
 ifeq (${OS_NAME},Linux)
 DYN_SUFFIX=.so
@@ -30,8 +30,8 @@ CXXFLAGS= -std=c++11 -g -Wall -Wextra -Wshadow -Werror
 
 GSL_CFLAGS=`pkg-config gsl --cflags`
 GSL_LDFLAGS=`pkg-config gsl --libs`
-HDF5_CFLAGS=-I$(H5DIR)/../include
-HDF5_LDFLAGS=-L$(H5DIR) -lhdf5_hl -lhdf5 -L/usr/local/opt/szip/lib  -lz -ldl -lm
+HDF5_CFLAGS=-I$(H5DIR)
+HDF5_LDFLAGS=-L$(H5DIR) -lhdf5_serial_hl -lhdf5_serial -L/usr/local/opt/szip/lib  -lz -ldl -lm
 
 INCnuFATE=$(PATH_nuFATE)/include
 LIBnuFATE=$(PATH_nuFATE)/lib

--- a/README.md
+++ b/README.md
@@ -12,10 +12,22 @@ can probably be obtained from your favorite package manager:
 * scipy: http://www.scipy.org/
 * tables: https://pypi.python.org/pypi/tables
 
+To install these with `pip`:
+
+```bash
+pip install numpy scipy tables
+```
+
 Recommended:
 * ipython: http://ipython.org/
 * jupyter: http://jupyter.readthedocs.io/
 * matplotlib: http://matplotlib.org/
+
+To install these with `pip`:
+
+```bash
+pip install ipython jupyter matplotlib
+```
 
 For the C++ version, you will need:
 
@@ -23,17 +35,26 @@ For the C++ version, you will need:
 * gsl (>= 1.15): http://www.gnu.org/software/gsl/
 * C++ compiler with C++11 support
 
+To install these with the `apt` package manager:
+
+```bash
+sudo apt install libhdf5-dev libgsl-dev g++ -y
+```
 
 Compiling
 ---------
 
 The Python interface can be installed by simply running:
 
-  python setup.py install
+```bash
+python setup.py install
+```
 
 Without write permissions, you can install it using:
 
-  python setup.py install --user
+```bash
+python setup.py install --user
+```
 
 The library can be compiled by running:
 


### PR DESCRIPTION
Changed the location of the hdf5 library files to match the current Ubuntu installation from `sudo apt install libhdf5-dev`. Not sure if this breaks an OSX installation.
Also included how to install the dependencies from the bash command line in the README.